### PR TITLE
removes hardcoded namespace

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -6,4 +6,5 @@ class Module extends \yii\base\Module
 {
 	public $layout = "bare";
 	public $basePath = "@app/vendor/synatree/yii2-dynamic-relations";
+	public $appAsset = "app\assets\AppAsset";
 }

--- a/views/layouts/bare.php
+++ b/views/layouts/bare.php
@@ -1,11 +1,12 @@
 <?php
 use yii\helpers\Html;
-use app\assets\AppAsset;
+use synatree\dynamicrelations\Module;
 
 /* @var $this \yii\web\View */
 /* @var $content string */
 
-AppAsset::register($this);
+$assetClass = Module::getInstance()->appAsset;
+$assetClass::register($this);
 
 $this->beginPage();
 ?>


### PR DESCRIPTION
This is a great module, thank you for releasing it.
The layout file expects the default AssedBundle to reside in namespace app\assets\AppAsset. This causes an error when using this module with the Yii2 advanced application template, because instead of a single 'app' namespace we have the namespaces 'backend, frontend, common'.
I changed the code so that the namespace for the AssetBundle can be set in the module configuration. That way, the module can be used with the advanced template as well.
