### PR TITLE
Check if there's a new model to avoid an undefined index notice.

### DIFF
--- a/DynamicRelations.php
+++ b/DynamicRelations.php
@@ -57,7 +57,7 @@ class DynamicRelations extends Widget
 	{
 		if($request[$name])
 		{
-			if($new = $request[$name]['new'])
+			if(isset($request[$name]['new']) && $new = $request[$name]['new'])
 			{
 				foreach( $new as $useless=>$newattrs)
 				{


### PR DESCRIPTION
This request fixes an `Undefined index: new` notice that is thrown when editing relations without adding new ones. If no new relations are added there are no models under the `['new']` array so the notice is thrown. The fix adds an `isset` check on the `$request[$name]['new']` statement.

Full error:

```
PHP Notice – yii\base\ErrorException
Undefined index: new
in vendor\synatree\yii2-dynamic-relations\DynamicRelations.php at line 60
```
